### PR TITLE
Manually called Thread.interrupt() to re-interrupt the current thread.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -83,6 +83,7 @@ public class KmzTrackExporter implements TrackExporter {
             return true;
         } catch (InterruptedException | IOException e) {
             Log.e(TAG, "Unable to write track", e);
+            Thread.currentThread().interrupt();
             return false;
         }
     }


### PR DESCRIPTION
Calling Thread.interrupt() ensures that the thread will be interrupted when InterruptedException is caught and will not risk delaying the thread shutdown or lose the information that the thread was interrupted.

Code Changes:
![image](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/assets/41756221/94210116-6aeb-4a60-804a-3cec97c9bdce)

Build Status: Successful
![image](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/assets/41756221/57370939-49ca-46a6-af54-c008431cd68d)
