### PR TITLE
Use of isEmpty() for issue #11

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/XMLImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/XMLImporter.java
@@ -47,7 +47,7 @@ public class XMLImporter {
             return parser.getImportTrackIds();
         } catch (SAXException | ParserConfigurationException | ParsingException e) {
             Log.e(TAG, "Unable to import file", e);
-            if (parser.getImportTrackIds().size() > 0) {
+            if (parser.getImportTrackIds().isEmpty()) {
                 parser.cleanImport();
             }
             throw new ImportParserException(e);


### PR DESCRIPTION
Use isEmpty() to check whether the collection is empty or not. Deliverables Solved!


**Proposed Solution:** 
Use of isEmpty() directly conveys the intent of checking whether the collection has elements or not, making the code more concise and easier to understand. This practice aligns with Java best practices and enhances code readability, maintainability, and clarity for developers who review or modify the codebase.

**Changes Made:**
- Use of isEmpty() instead of regular comparison.

**Impact:**
This issue aims to improve code quality and readability by applying this simple but effective improvement throughout the relevant codebase.

**Link to the the issue**
https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/11#issue-2137684653

<img width="779" alt="Screenshot 2024-02-15 at 8 06 33 PM" src="https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/assets/42618525/d342bb8c-47d2-43af-998e-a79262faf00b">

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
